### PR TITLE
Fix compiler errors with latest zig (0.9.0-dev.894+4f0aa7d63)

### DIFF
--- a/src/zuri.zig
+++ b/src/zuri.zig
@@ -133,7 +133,7 @@ pub const Uri = struct {
         var list = std.ArrayList([]const u8).init(allocator);
         defer list.deinit();
 
-        var it = mem.tokenize(path, "/");
+        var it = mem.tokenize(u8, path, "/");
         while (it.next()) |p| {
             if (mem.eql(u8, p, ".")) {
                 continue;
@@ -406,167 +406,167 @@ pub const Uri = struct {
 
 test "basic url" {
     const uri = try Uri.parse("https://ziglang.org:80/documentation/master/?test#toc-Introduction", false);
-    expectEqualStrings("https", uri.scheme);
-    expectEqualStrings("", uri.username);
-    expectEqualStrings("", uri.password);
-    expectEqualStrings("ziglang.org", uri.host.name);
-    expect(uri.port.? == 80);
-    expectEqualStrings("/documentation/master/", uri.path);
-    expectEqualStrings("test", uri.query);
-    expectEqualStrings("toc-Introduction", uri.fragment);
-    expect(uri.len == 66);
+    try expectEqualStrings("https", uri.scheme);
+    try expectEqualStrings("", uri.username);
+    try expectEqualStrings("", uri.password);
+    try expectEqualStrings("ziglang.org", uri.host.name);
+    try expect(uri.port.? == 80);
+    try expectEqualStrings("/documentation/master/", uri.path);
+    try expectEqualStrings("test", uri.query);
+    try expectEqualStrings("toc-Introduction", uri.fragment);
+    try expect(uri.len == 66);
 }
 
 test "short" {
     const uri = try Uri.parse("telnet://192.0.2.16:80/", false);
-    expectEqualStrings("telnet", uri.scheme);
-    expectEqualStrings("", uri.username);
-    expectEqualStrings("", uri.password);
+    try expectEqualStrings("telnet", uri.scheme);
+    try expectEqualStrings("", uri.username);
+    try expectEqualStrings("", uri.password);
     var buf = [_]u8{0} ** 100;
     var ip = std.fmt.bufPrint(buf[0..], "{}", .{uri.host.ip}) catch unreachable;
-    expectEqualStrings("192.0.2.16:80", ip);
-    expect(uri.port.? == 80);
-    expectEqualStrings("/", uri.path);
-    expectEqualStrings("", uri.query);
-    expectEqualStrings("", uri.fragment);
-    expect(uri.len == 23);
+    try expectEqualStrings("192.0.2.16:80", ip);
+    try expect(uri.port.? == 80);
+    try expectEqualStrings("/", uri.path);
+    try expectEqualStrings("", uri.query);
+    try expectEqualStrings("", uri.fragment);
+    try expect(uri.len == 23);
 }
 
 test "single char" {
     const uri = try Uri.parse("a", false);
-    expectEqualStrings("", uri.scheme);
-    expectEqualStrings("", uri.username);
-    expectEqualStrings("", uri.password);
-    expectEqualStrings("", uri.host.name);
-    expect(uri.port == null);
-    expectEqualStrings("a", uri.path);
-    expectEqualStrings("", uri.query);
-    expectEqualStrings("", uri.fragment);
-    expect(uri.len == 1);
+    try expectEqualStrings("", uri.scheme);
+    try expectEqualStrings("", uri.username);
+    try expectEqualStrings("", uri.password);
+    try expectEqualStrings("", uri.host.name);
+    try expect(uri.port == null);
+    try expectEqualStrings("a", uri.path);
+    try expectEqualStrings("", uri.query);
+    try expectEqualStrings("", uri.fragment);
+    try expect(uri.len == 1);
 }
 
 test "ipv6" {
     const uri = try Uri.parse("ldap://[2001:db8::7]/c=GB?objectClass?one", false);
-    expectEqualStrings("ldap", uri.scheme);
-    expectEqualStrings("", uri.username);
-    expectEqualStrings("", uri.password);
+    try expectEqualStrings("ldap", uri.scheme);
+    try expectEqualStrings("", uri.username);
+    try expectEqualStrings("", uri.password);
     var buf = [_]u8{0} ** 100;
     var ip = std.fmt.bufPrint(buf[0..], "{}", .{uri.host.ip}) catch unreachable;
-    expectEqualStrings("[2001:db8::7]:389", ip);
-    expect(uri.port.? == 389);
-    expectEqualStrings("/c=GB", uri.path);
-    expectEqualStrings("objectClass?one", uri.query);
-    expectEqualStrings("", uri.fragment);
-    expect(uri.len == 41);
+    try expectEqualStrings("[2001:db8::7]:389", ip);
+    try expect(uri.port.? == 389);
+    try expectEqualStrings("/c=GB", uri.path);
+    try expectEqualStrings("objectClass?one", uri.query);
+    try expectEqualStrings("", uri.fragment);
+    try expect(uri.len == 41);
 }
 
 test "mailto" {
     const uri = try Uri.parse("mailto:John.Doe@example.com", false);
-    expectEqualStrings("mailto", uri.scheme);
-    expectEqualStrings("", uri.username);
-    expectEqualStrings("", uri.password);
-    expectEqualStrings("", uri.host.name);
-    expect(uri.port == null);
-    expectEqualStrings("John.Doe@example.com", uri.path);
-    expectEqualStrings("", uri.query);
-    expectEqualStrings("", uri.fragment);
-    expect(uri.len == 27);
+    try expectEqualStrings("mailto", uri.scheme);
+    try expectEqualStrings("", uri.username);
+    try expectEqualStrings("", uri.password);
+    try expectEqualStrings("", uri.host.name);
+    try expect(uri.port == null);
+    try expectEqualStrings("John.Doe@example.com", uri.path);
+    try expectEqualStrings("", uri.query);
+    try expectEqualStrings("", uri.fragment);
+    try expect(uri.len == 27);
 }
 
 test "tel" {
     const uri = try Uri.parse("tel:+1-816-555-1212", false);
-    expectEqualStrings("tel", uri.scheme);
-    expectEqualStrings("", uri.username);
-    expectEqualStrings("", uri.password);
-    expectEqualStrings("", uri.host.name);
-    expect(uri.port == null);
-    expectEqualStrings("+1-816-555-1212", uri.path);
-    expectEqualStrings("", uri.query);
-    expectEqualStrings("", uri.fragment);
-    expect(uri.len == 19);
+    try expectEqualStrings("tel", uri.scheme);
+    try expectEqualStrings("", uri.username);
+    try expectEqualStrings("", uri.password);
+    try expectEqualStrings("", uri.host.name);
+    try expect(uri.port == null);
+    try expectEqualStrings("+1-816-555-1212", uri.path);
+    try expectEqualStrings("", uri.query);
+    try expectEqualStrings("", uri.fragment);
+    try expect(uri.len == 19);
 }
 
 test "urn" {
     const uri = try Uri.parse("urn:oasis:names:specification:docbook:dtd:xml:4.1.2", false);
-    expectEqualStrings("urn", uri.scheme);
-    expectEqualStrings("", uri.username);
-    expectEqualStrings("", uri.password);
-    expectEqualStrings("", uri.host.name);
-    expect(uri.port == null);
-    expectEqualStrings("oasis:names:specification:docbook:dtd:xml:4.1.2", uri.path);
-    expectEqualStrings("", uri.query);
-    expectEqualStrings("", uri.fragment);
-    expect(uri.len == 51);
+    try expectEqualStrings("urn", uri.scheme);
+    try expectEqualStrings("", uri.username);
+    try expectEqualStrings("", uri.password);
+    try expectEqualStrings("", uri.host.name);
+    try expect(uri.port == null);
+    try expectEqualStrings("oasis:names:specification:docbook:dtd:xml:4.1.2", uri.path);
+    try expectEqualStrings("", uri.query);
+    try expectEqualStrings("", uri.fragment);
+    try expect(uri.len == 51);
 }
 
 test "userinfo" {
     const uri = try Uri.parse("ftp://username:password@host.com/", false);
-    expectEqualStrings("ftp", uri.scheme);
-    expectEqualStrings("username", uri.username);
-    expectEqualStrings("password", uri.password);
-    expectEqualStrings("host.com", uri.host.name);
-    expect(uri.port.? == 21);
-    expectEqualStrings("/", uri.path);
-    expectEqualStrings("", uri.query);
-    expectEqualStrings("", uri.fragment);
-    expect(uri.len == 33);
+    try expectEqualStrings("ftp", uri.scheme);
+    try expectEqualStrings("username", uri.username);
+    try expectEqualStrings("password", uri.password);
+    try expectEqualStrings("host.com", uri.host.name);
+    try expect(uri.port.? == 21);
+    try expectEqualStrings("/", uri.path);
+    try expectEqualStrings("", uri.query);
+    try expectEqualStrings("", uri.fragment);
+    try expect(uri.len == 33);
 }
 
 test "map query" {
     const uri = try Uri.parse("https://ziglang.org:80/documentation/master/?test;1=true&false#toc-Introduction", false);
-    expectEqualStrings("https", uri.scheme);
-    expectEqualStrings("", uri.username);
-    expectEqualStrings("", uri.password);
-    expectEqualStrings("ziglang.org", uri.host.name);
-    expect(uri.port.? == 80);
-    expectEqualStrings("/documentation/master/", uri.path);
-    expectEqualStrings("test;1=true&false", uri.query);
-    expectEqualStrings("toc-Introduction", uri.fragment);
+    try expectEqualStrings("https", uri.scheme);
+    try expectEqualStrings("", uri.username);
+    try expectEqualStrings("", uri.password);
+    try expectEqualStrings("ziglang.org", uri.host.name);
+    try expect(uri.port.? == 80);
+    try expectEqualStrings("/documentation/master/", uri.path);
+    try expectEqualStrings("test;1=true&false", uri.query);
+    try expectEqualStrings("toc-Introduction", uri.fragment);
     var map = try Uri.mapQuery(std.testing.allocator, uri.query);
     defer map.deinit();
-    expectEqualStrings("true", map.get("test;1").?);
-    expectEqualStrings("", map.get("false").?);
+    try expectEqualStrings("true", map.get("test;1").?);
+    try expectEqualStrings("", map.get("false").?);
 }
 
 test "ends in space" {
     const uri = try Uri.parse("https://ziglang.org/documentation/master/ something else", false);
-    expectEqualStrings("https", uri.scheme);
-    expectEqualStrings("", uri.username);
-    expectEqualStrings("", uri.password);
-    expectEqualStrings("ziglang.org", uri.host.name);
-    expectEqualStrings("/documentation/master/", uri.path);
-    expect(uri.len == 41);
+    try expectEqualStrings("https", uri.scheme);
+    try expectEqualStrings("", uri.username);
+    try expectEqualStrings("", uri.password);
+    try expectEqualStrings("ziglang.org", uri.host.name);
+    try expectEqualStrings("/documentation/master/", uri.path);
+    try expect(uri.len == 41);
 }
 
 test "assume auth" {
     const uri = try Uri.parse("ziglang.org", true);
-    expectEqualStrings("ziglang.org", uri.host.name);
-    expect(uri.len == 11);
+    try expectEqualStrings("ziglang.org", uri.host.name);
+    try expect(uri.len == 11);
 }
 
 test "username contains @" {
     const uri = try Uri.parse("https://1.1.1.1&@2.2.2.2%23@3.3.3.3", false);
-    expectEqualStrings("https", uri.scheme);
-    expectEqualStrings("1.1.1.1&@2.2.2.2%23", uri.username);
-    expectEqualStrings("", uri.password);
+    try expectEqualStrings("https", uri.scheme);
+    try expectEqualStrings("1.1.1.1&@2.2.2.2%23", uri.username);
+    try expectEqualStrings("", uri.password);
     var buf = [_]u8{0} ** 100;
     var ip = std.fmt.bufPrint(buf[0..], "{}", .{uri.host.ip}) catch unreachable;
-    expectEqualStrings("3.3.3.3:443", ip);
-    expect(uri.port.? == 443);
-    expectEqualStrings("", uri.path);
-    expect(uri.len == 35);
+    try expectEqualStrings("3.3.3.3:443", ip);
+    try expect(uri.port.? == 443);
+    try expectEqualStrings("", uri.path);
+    try expect(uri.len == 35);
 }
 
 test "encode" {
     const path = (try Uri.encode(testing.allocator, "/안녕하세요.html")).?;
     defer testing.allocator.free(path);
-    expectEqualStrings("/%EC%95%88%EB%85%95%ED%95%98%EC%84%B8%EC%9A%94.html", path);
+    try expectEqualStrings("/%EC%95%88%EB%85%95%ED%95%98%EC%84%B8%EC%9A%94.html", path);
 }
 
 test "decode" {
     const path = (try Uri.decode(testing.allocator, "/%EC%95%88%EB%85%95%ED%95%98%EC%84%B8%EC%9A%94.html")).?;
     defer testing.allocator.free(path);
-    expectEqualStrings("/안녕하세요.html", path);
+    try expectEqualStrings("/안녕하세요.html", path);
 }
 
 test "resolvePath" {
@@ -575,17 +575,17 @@ test "resolvePath" {
     const alloc = &arena.allocator;
 
     var a = try Uri.resolvePath(alloc, "/a/b/..");
-    expectEqualStrings("/a", a);
+    try expectEqualStrings("/a", a);
     a = try Uri.resolvePath(alloc, "/a/b/../");
-    expectEqualStrings("/a/", a);
+    try expectEqualStrings("/a/", a);
     a = try Uri.resolvePath(alloc, "/a/b/c/../d/../");
-    expectEqualStrings("/a/b/", a);
+    try expectEqualStrings("/a/b/", a);
     a = try Uri.resolvePath(alloc, "/a/b/c/../d/..");
-    expectEqualStrings("/a/b", a);
+    try expectEqualStrings("/a/b", a);
     a = try Uri.resolvePath(alloc, "/a/b/c/../d/.././");
-    expectEqualStrings("/a/b/", a);
+    try expectEqualStrings("/a/b/", a);
     a = try Uri.resolvePath(alloc, "/a/b/c/../d/../.");
-    expectEqualStrings("/a/b", a);
+    try expectEqualStrings("/a/b", a);
     a = try Uri.resolvePath(alloc, "/a/../../");
-    expectEqualStrings("/", a);
+    try expectEqualStrings("/", a);
 }


### PR DESCRIPTION
- Added "try" before "expect" in all test cases
- Added type to mem.tokenize

'zig test test.zig' works with a recent upstream zig compiler (mine is 0.9.0-dev.894+4f0aa7d63)