### PR TITLE
Update for latest Zig allocator changes

### DIFF
--- a/src/zuri.zig
+++ b/src/zuri.zig
@@ -96,7 +96,7 @@ pub const Uri = struct {
             }
         }
 
-        if (ret) |some| return allocator.shrink(some, ret_index);
+        if (ret) |some| return try allocator.realloc(some, ret_index);
         return null;
     }
 


### PR DESCRIPTION
The `try` was necessary to avoid a slightly unexpected error:

```
lib\zuri\src\zuri.zig:99:49: error: expected type 'error{InvalidCharacter,OutOfMemory}!?[]u8', found 'error{OutOfMemory}![]u8'
        if (ret) |some| return allocator.realloc(some, ret_index);
                               ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
lib\zuri\src\zuri.zig:99:49: note: error union payload '[]u8' cannot cast into error union payload '?[]u8'
lib\zuri\src\zuri.zig:68:70: note: function return type declared here
    pub fn decode(allocator: Allocator, path: []const u8) EncodeError!?[]u8 {
                                                          ~~~~~~~~~~~^~~~~~
```